### PR TITLE
Adding some XSS sanitization for the phone number and the races string.

### DIFF
--- a/cgi/subscribe.cgi
+++ b/cgi/subscribe.cgi
@@ -43,7 +43,9 @@ print "<a href='http://alaskaelectionwatch.com'><img src='/electionwatch.png' cl
 my $phone = $cgi->param("phone");
 if("$phone" ne "")
 {
-	# validate phone number
+	# Sanitize Phone number
+        $phone =~ s/[^0-9]+//g;
+        # validate phone number
         my $nk = $phone;
         $nk =~ s/[^0-9]//g;
         $nk =~ s/^[01]*//;
@@ -85,6 +87,8 @@ if("$phone" ne "")
 		print "<ul>\n";
 		foreach my $r (@races)
 		{
+                        # Sanitize races strings.
+                        $r =~ s/[^-a-zA-Z0-9_.@ ]+//g;
 			print "<li>$r</li>\n";
 		}
 	


### PR DESCRIPTION
There were some XSS bugs I found which can be pretty nasty.

Google Chrome has XSS protection but the below exploit worked on Firefox.
http://alaskaelectionwatch.com/?phone=%3Cscript%3Ealert(%27xss%27)%3C/script%3E

Also there is no validation on the races string.  Are these getting written to a file?  If so depending on the location of the file something like a PHP shell could easily be uploaded through one of these vars.
